### PR TITLE
Added UTF-8 support for QR-Codes

### DIFF
--- a/qrutil.typ
+++ b/qrutil.typ
@@ -308,9 +308,13 @@
 #let encode-byte(chars, buffer) = {
   let code = ()
   let len = chars.len()
+  let codepoints = chars.codepoints()
 
-  for i in range(len) {
-    buffer += bits.from-int( 32 + ASCII.position(chars.at(i)), pad:8 )
+  for cp in codepoints {
+    buffer += bits.from-int(
+      cp.to-unicode(),
+      pad: 8
+    )
 
     while buffer.len() >= 8 {
       code.push( bits.to-int(buffer.slice(0, 8)) )


### PR DESCRIPTION
This pull request adds support for encoding UTF-8 characters (not only ASCII) in QR-Codes
According to the QR-Code standard, characters should be encoded using the Latin-1 charset (aka. ISO-8859-1), but I don't think it is possible yet using Typst's native functions. Since it only makes a difference for multibyte characters, UTF-8 should already work for a number of use cases

PS: For some reason I can't seem to make Mantys work to update the manual
